### PR TITLE
(feat) Add header publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:4-alpine
+        ports:
+          - 5672:5672
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/src/carotte/publisher.gleam
+++ b/src/carotte/publisher.gleam
@@ -1,5 +1,61 @@
 import carotte
 import carotte/channel
+import gleam/dynamic
+import gleam/erlang/atom
+import gleam/list
+
+// In amqp_client, headers are represented as a proplist of
+// {Name, Type, Data}.
+// Name is a binary representation of the header name.
+// Type is one of a number of type atoms, but in our case, we only care about:
+// - bool - Bool
+// - long - Int
+// - float - Float
+// - longstr - String
+// - array - List
+
+pub opaque type HeaderList {
+  HeaderList(List(#(String, atom.Atom, dynamic.Dynamic)))
+}
+
+pub type HeaderValue {
+  BoolHeader(Bool)
+  FloatHeader(Float)
+  IntHeader(Int)
+  StringHeader(String)
+  ListHeader(List(HeaderValue))
+}
+
+fn header_value_to_header_tuple(
+  value: HeaderValue,
+) -> #(atom.Atom, dynamic.Dynamic) {
+  case value {
+    BoolHeader(value) -> #(atom.create_from_string("bool"), dynamic.from(value))
+    FloatHeader(value) -> #(
+      atom.create_from_string("float"),
+      dynamic.from(value),
+    )
+    IntHeader(value) -> #(atom.create_from_string("long"), dynamic.from(value))
+    StringHeader(value) -> #(
+      atom.create_from_string("longstr"),
+      dynamic.from(value),
+    )
+    ListHeader(value) -> #(
+      atom.create_from_string("array"),
+      dynamic.from(value |> list.map(header_value_to_header_tuple)),
+    )
+  }
+}
+
+pub fn headers_from_list(list: List(#(String, HeaderValue))) -> HeaderList {
+  list
+  |> list.map(fn(item) {
+    let #(name, value) = item
+    let #(type_atom, value) = header_value_to_header_tuple(value)
+    #(name, type_atom, value)
+  })
+  |> HeaderList
+}
 
 pub type PublishOption {
   /// If set, returns an error if the broker can't route the message to a queue
@@ -9,7 +65,10 @@ pub type PublishOption {
   ContentType(String)
   /// MIME Content encoding
   ContentEncoding(String)
-  /// If set, uses persistent delivery mode. 
+  /// Headers to attach to the message. Note: headers can currently only be sent,
+  /// not received.
+  Headers(HeaderList)
+  /// If set, uses persistent delivery mode.
   /// Messages marked as persistent that are delivered to durable queues will be logged to disk
   Persistent(Bool)
   /// Arbitrary application-specific message identifier

--- a/src/carotte_ffi.erl
+++ b/src/carotte_ffi.erl
@@ -238,10 +238,14 @@ queue_purge(Channel, Queue, Nowait) ->
 -record('P_basic', {content_type, content_encoding, headers, delivery_mode, priority, correlation_id, reply_to, expiration, message_id, timestamp, type, user_id, app_id, cluster_id}).
 -record(amqp_msg, {props = #'P_basic'{}, payload = <<>>}).
 publish(Channel, Exchange, RoutingKey, Payload, Proplist) ->
+  Headers = case proplists:get_value(headers, Proplist, undefined) of
+    {header_list, HeaderList} -> HeaderList;
+    _ -> undefined
+  end,
   Props = #'P_basic'{
              content_type = proplists:get_value(content_type, Proplist, undefined), 
                      content_encoding = proplists:get_value(content_encoding, Proplist, undefined), 
-                     headers = proplists:get_value(headers, Proplist, undefined), 
+                     headers = Headers, 
                      delivery_mode = case proplists:get_value(persistent, Proplist, false) of true -> 2; false -> 1 end, 
                      priority = proplists:get_value(priority, Proplist, undefined), 
                      correlation_id = proplists:get_value(correlation_id, Proplist, undefined), 

--- a/test/carotte_test.gleam
+++ b/test/carotte_test.gleam
@@ -4,7 +4,6 @@ import carotte/exchange
 import carotte/publisher
 import carotte/queue
 import gleam/erlang/process
-import gleam/io
 import gleeunit
 import gleeunit/should
 
@@ -323,7 +322,7 @@ pub fn publish_test() {
   |> should.be_ok()
 }
 
-pub fn publish_with_options_tes() {
+pub fn publish_with_options_test() {
   let client =
     carotte.default_client()
     |> carotte.start()
@@ -341,6 +340,19 @@ pub fn publish_with_options_tes() {
   |> queue.declare(channel)
   |> should.be_ok()
 
+  let headers =
+    publisher.headers_from_list([
+      #("string_key", publisher.StringHeader("value")),
+      #("bool_key", publisher.BoolHeader(True)),
+      #(
+        "list_key",
+        publisher.ListHeader([
+          publisher.StringHeader("value1"),
+          publisher.StringHeader("value2"),
+        ]),
+      ),
+    ])
+
   publisher.publish(
     channel: channel,
     exchange: "pwo_exchange",
@@ -350,6 +362,7 @@ pub fn publish_with_options_tes() {
       publisher.Mandatory(True),
       publisher.ContentType("text/plain"),
       publisher.ContentEncoding("utf-8"),
+      publisher.Headers(headers),
       publisher.Persistent(True),
       publisher.CorrelationId("123"),
       publisher.Priority(9),


### PR DESCRIPTION
Closes #3 by adding header publishing functionality. This PR doesn't add support for reading headers from incoming messages, as that would need handling for all the different header types RabbitMQ supports.

I've also taken the liberty of adding a RabbitMQ service container to the GitHub workflow, so the tests have something to run against.