### PR TITLE
Add AuthFailure variant to the CarotteError type

### DIFF
--- a/src/carotte.gleam
+++ b/src/carotte.gleam
@@ -7,6 +7,7 @@ pub type CarotteClient {
 pub type CarotteError {
   Blocked
   Closed
+  AuthFailure(BitArray)
 }
 
 pub opaque type Builder {

--- a/src/carotte.gleam
+++ b/src/carotte.gleam
@@ -7,7 +7,7 @@ pub type CarotteClient {
 pub type CarotteError {
   Blocked
   Closed
-  AuthFailure(BitArray)
+  AuthFailure(String)
 }
 
 pub opaque type Builder {

--- a/src/carotte_ffi.erl
+++ b/src/carotte_ffi.erl
@@ -44,7 +44,11 @@ start(Username,
     {ok, Pid} ->
       {ok, #carotte_client{pid = Pid}};
     {error, Error} ->
-      {error, Error}
+      case Error of
+        {Err, Msg} ->
+          {error, {Err, erlang:list_to_binary(Msg)}};
+        _ -> {error, Error}
+        end
   end.
 
 open_channel(CarotteClient) ->

--- a/test/carotte_test.gleam
+++ b/test/carotte_test.gleam
@@ -487,9 +487,7 @@ pub fn auth_failure_test() {
   |> carotte.with_password("wrong")
   |> carotte.start()
   |> should.be_error()
-  |> should.equal(
-    carotte.AuthFailure(<<
-      "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.":utf8,
-    >>),
-  )
+  |> should.equal(carotte.AuthFailure(
+    "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.",
+  ))
 }

--- a/test/carotte_test.gleam
+++ b/test/carotte_test.gleam
@@ -483,11 +483,8 @@ pub fn unsubscribe_test() {
 }
 
 pub fn auth_failure_test() {
-  carotte.default_client()
-  |> carotte.with_password("wrong")
-  |> carotte.start()
-  |> should.be_error()
-  |> should.equal(carotte.AuthFailure(
-    "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.",
-  ))
+  let assert Error(carotte.AuthFailure(_)) =
+    carotte.default_client()
+    |> carotte.with_password("wrong")
+    |> carotte.start()
 }

--- a/test/carotte_test.gleam
+++ b/test/carotte_test.gleam
@@ -481,3 +481,15 @@ pub fn unsubscribe_test() {
   |> should.be_ok()
   process.sleep(1000)
 }
+
+pub fn auth_failure_test() {
+  carotte.default_client()
+  |> carotte.with_password("wrong")
+  |> carotte.start()
+  |> should.be_error()
+  |> should.equal(
+    carotte.AuthFailure(<<
+      "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.":utf8,
+    >>),
+  )
+}


### PR DESCRIPTION
Adds a new `AuthFailure(BitArray)` error variant the `CarotteError` type so we can tell when login fails